### PR TITLE
Add `netherdepthsupgrade` flag to `lava_fishing_net` recipe

### DIFF
--- a/src/generated/resources/data/create_integrated_farming/recipe/crafting/lava_fishing_net.json
+++ b/src/generated/resources/data/create_integrated_farming/recipe/crafting/lava_fishing_net.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "netherdepthsupgrade"
+    }
+  ],
   "type": "minecraft:crafting_shaped",
   "category": "misc",
   "key": {


### PR DESCRIPTION
- Added the `netherdepthsupgrade` presence flag.

Although it looks a bit weird, since `netherdepthsupgrade` isn't mentioned in the recipe itself, but I guess you have a somehow implemented compatibility with Nether Depths Upgrade mod so that `lava_fishing_net` item isn't registered in the absence of this mod, however, the recipe is still trying to.

Closes https://github.com/DragonsPlusMinecraft/CreateIntegratedFarming/issues/6.