### PR TITLE
feat: make inventory of chicken roost configurable.

### DIFF
--- a/src/main/java/plus/dragons/createintegratedfarming/common/ranching/roost/chicken/ChickenRoostBlockEntity.java
+++ b/src/main/java/plus/dragons/createintegratedfarming/common/ranching/roost/chicken/ChickenRoostBlockEntity.java
@@ -50,6 +50,7 @@ import net.neoforged.neoforge.items.ItemStackHandler;
 import org.jetbrains.annotations.Nullable;
 import plus.dragons.createintegratedfarming.common.registry.CIFDataMaps;
 import plus.dragons.createintegratedfarming.common.registry.CIFLootTables;
+import plus.dragons.createintegratedfarming.config.CIFConfig;
 
 public class ChickenRoostBlockEntity extends SmartBlockEntity {
     protected final ItemStackHandler inventory;
@@ -60,10 +61,10 @@ public class ChickenRoostBlockEntity extends SmartBlockEntity {
     public ChickenRoostBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
         setLazyTickRate(20);
-        this.inventory = new ItemStackHandler(9) {
+        this.inventory = new ItemStackHandler(CIFConfig.server().roostingInventorySlotCount.get()) {
             @Override
             public int getSlotLimit(int slot) {
-                return 1;
+                return CIFConfig.server().roostingInventorySlotSize.get();
             }
         };
         this.outputHandler = new ItemHandlerWrapper(inventory) {

--- a/src/main/java/plus/dragons/createintegratedfarming/config/CIFServerConfig.java
+++ b/src/main/java/plus/dragons/createintegratedfarming/config/CIFServerConfig.java
@@ -49,6 +49,12 @@ public class CIFServerConfig extends ConfigBase {
     public final ConfigBool leashedEntitySitsAutomatically = b(false,
             "leashedEntitySitsAutomatically",
             Comments.leashedEntitySitsAutomatically);
+    public final ConfigInt roostingInventorySlotCount = i(9, 1, 27,
+            "roostingInventorySlotCount",
+            Comments.roostingInventorySlotCount);
+    public final ConfigInt roostingInventorySlotSize = i(1, 1, 16,
+            "roostingInventorySlotSize",
+            Comments.roostingInventorySlotSize);
 
     @Override
     public String getName() {
@@ -90,5 +96,7 @@ public class CIFServerConfig extends ConfigBase {
                 "When enabled, falls back to vanilla Create behaviour.",
                 "When disabled, seated leashable entity can be dismounted by lead."
         };
+        static final String roostingInventorySlotCount = "The amount of Inventory Slot that the Chicken Roost has available.";
+        static final String roostingInventorySlotSize = "The amount of items per Inventory slot that the Chicken Roost can hold.";
     }
 }


### PR DESCRIPTION
This changes the hardcoded values for the constructor of `ChickenRoostBlockEntity.java` to use configuration values within the config to allow modification. This will allow more in-depth configuration for modpacks to use when modifying loot tables. This also solves my feature request #24 