### PR TITLE
Fix Farmers Delight tomato compatibility (FD 1.2.11)

### DIFF
--- a/src/integration/farmersdelight/java/plus/dragons/createintegratedfarming/integration/farmersdelight/farming/harvest/TomatoHarvestBehaviour.java
+++ b/src/integration/farmersdelight/java/plus/dragons/createintegratedfarming/integration/farmersdelight/farming/harvest/TomatoHarvestBehaviour.java
@@ -27,7 +27,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 import plus.dragons.createintegratedfarming.api.harvester.CustomHarvestBehaviour;
 import vectorwing.farmersdelight.common.Configuration;
 import vectorwing.farmersdelight.common.block.TomatoVineBlock;
@@ -40,6 +42,12 @@ public class TomatoHarvestBehaviour implements CustomHarvestBehaviour {
 
     public TomatoHarvestBehaviour(TomatoVineBlock tomato) {
         this.tomato = tomato;
+    }
+
+    public static @Nullable TomatoHarvestBehaviour create(Block block) {
+        if (!(block instanceof TomatoVineBlock tomato))
+            return null;
+        return new TomatoHarvestBehaviour(tomato);
     }
 
     @Override

--- a/src/integration/farmersdelight/java/plus/dragons/createintegratedfarming/integration/farmersdelight/registry/FDHarvestBehaviors.java
+++ b/src/integration/farmersdelight/java/plus/dragons/createintegratedfarming/integration/farmersdelight/registry/FDHarvestBehaviors.java
@@ -21,13 +21,10 @@ package plus.dragons.createintegratedfarming.integration.farmersdelight.registry
 import plus.dragons.createintegratedfarming.api.harvester.CustomHarvestBehaviour;
 import plus.dragons.createintegratedfarming.integration.farmersdelight.farming.harvest.MushroomColonyHarvestBehaviour;
 import plus.dragons.createintegratedfarming.integration.farmersdelight.farming.harvest.TomatoHarvestBehaviour;
-import vectorwing.farmersdelight.common.block.TomatoVineBlock;
-import vectorwing.farmersdelight.common.registry.ModBlocks;
 
 public class FDHarvestBehaviors {
     public static void register() {
         CustomHarvestBehaviour.REGISTRY.registerProvider(MushroomColonyHarvestBehaviour::create);
-        var tomato = (TomatoVineBlock) ModBlocks.TOMATO_CROP.get();
-        CustomHarvestBehaviour.REGISTRY.register(tomato, new TomatoHarvestBehaviour(tomato));
+        CustomHarvestBehaviour.REGISTRY.registerProvider(TomatoHarvestBehaviour::create);
     }
 }


### PR DESCRIPTION
Replace direct TOMATO_CROP field linkage with TomatoVineBlock provider registration to avoid NoSuchFieldError caused by Farmers Delight API type changes.